### PR TITLE
Fix display bug in days lived message

### DIFF
--- a/Week1/script.js
+++ b/Week1/script.js
@@ -20,7 +20,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Utility: Check if day is singular or plural
   function formatDaysDisplay(days) {
-    return `You have lived ${days.toLocaleString()} ${
+    return `${days.toLocaleString()} ${
       days > 1 ? "days" : "day"
     }`;
   }


### PR DESCRIPTION
Fix: Corrected logic to display "You have lived {n} days" as intended instead of "You have lived You have lived {n} days"
<img width="1672" height="475" alt="Screenshot 2025-07-19 094543" src="https://github.com/user-attachments/assets/f805b4e0-926d-4f30-b0aa-1806f106cbc8" />

